### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+node_modules


### PR DESCRIPTION
I noticed that `.gitignore` was not excluding the `node_modules` directory, causing a massive amount of changes when a new module is added. All current branches should rebase after this is merged.